### PR TITLE
Add teacher admin mode for activity management

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,13 @@
 # Mergington High School Activities API
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+A super simple FastAPI application that allows students to view extracurricular activities while teachers manage registrations.
 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login backed by a JSON credential file
+- Register students for activities
+- Unregister students from activities
 
 ## Getting Started
 
@@ -18,19 +20,33 @@ A super simple FastAPI application that allows students to view and sign up for 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
+   - App: http://localhost:8000/
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
+
+## Teacher Access
+
+Teacher credentials are stored in `teachers.json`.
+
+Sample accounts:
+
+- `principal@mergington.edu` / `mergington-admin`
+- `coach.taylor@mergington.edu` / `falcons-rule`
 
 ## API Endpoints
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/auth/session`                                                   | Check whether a teacher is currently signed in                      |
+| POST   | `/auth/login`                                                     | Sign in as a teacher and create an authenticated session            |
+| POST   | `/auth/logout`                                                    | End the current teacher session                                     |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student for an activity                                  |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a student from an activity                                |
 
 ## Data Model
 
@@ -47,4 +63,4 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Activity data and teacher sessions are stored in memory, which means changes are reset when the server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,19 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+A super simple FastAPI application that allows students to view activities and
+teachers to manage extracurricular signups at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+import json
+import os
+import secrets
+from pathlib import Path
+
+from fastapi import Cookie, FastAPI, HTTPException, Response
+from pydantic import BaseModel
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,13 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+
+with teachers_file.open(encoding="utf-8") as file_handle:
+    teacher_accounts = json.load(file_handle)
+
+admin_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +89,18 @@ activities = {
 }
 
 
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def require_admin(admin_session: str | None):
+    if not admin_session or admin_session not in admin_sessions:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
+    return admin_sessions[admin_session]
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +111,51 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/session")
+def get_session_status(admin_session: str | None = Cookie(default=None)):
+    username = admin_sessions.get(admin_session)
+    return {
+        "authenticated": bool(username),
+        "username": username,
+    }
+
+
+@app.post("/auth/login")
+def login(payload: LoginRequest, response: Response):
+    expected_password = teacher_accounts.get(payload.username)
+
+    if expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    admin_sessions[session_token] = payload.username
+    response.set_cookie(
+        key="admin_session",
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+    )
+    return {"message": f"Signed in as {payload.username}", "username": payload.username}
+
+
+@app.post("/auth/logout")
+def logout(response: Response, admin_session: str | None = Cookie(default=None)):
+    if admin_session:
+        admin_sessions.pop(admin_session, None)
+
+    response.delete_cookie("admin_session")
+    return {"message": "Signed out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    admin_session: str | None = Cookie(default=None),
+):
     """Sign up a student for an activity"""
+    require_admin(admin_session)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +176,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    admin_session: str | None = Cookie(default=None),
+):
     """Unregister a student from an activity"""
+    require_admin(admin_session)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,60 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const teacherStatus = document.getElementById("teacher-status");
+  const adminToggle = document.getElementById("admin-toggle");
+  const adminToggleLabel = document.getElementById("admin-toggle-label");
+  const adminPanel = document.getElementById("admin-panel");
+  const adminPanelClose = document.getElementById("admin-panel-close");
+  const loginForm = document.getElementById("login-form");
+  const logoutButton = document.getElementById("logout-button");
+
+  let authState = {
+    authenticated: false,
+    username: null,
+  };
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function setAdminPanelOpen(isOpen) {
+    adminPanel.classList.toggle("hidden", !isOpen);
+    adminToggle.setAttribute("aria-expanded", String(isOpen));
+  }
+
+  function updateTeacherControls() {
+    const isTeacher = authState.authenticated;
+
+    signupForm.classList.toggle("disabled-form", !isTeacher);
+    Array.from(signupForm.elements).forEach((element) => {
+      element.disabled = !isTeacher;
+    });
+
+    if (isTeacher) {
+      teacherStatus.textContent = `Signed in as ${authState.username}. You can register or unregister students.`;
+      teacherStatus.className = "success info-banner";
+      adminToggleLabel.textContent = authState.username;
+      logoutButton.classList.remove("hidden");
+    } else {
+      teacherStatus.textContent = "Log in as a teacher to manage student registrations.";
+      teacherStatus.className = "info-banner";
+      adminToggleLabel.textContent = "Teacher Login";
+      logoutButton.classList.add("hidden");
+    }
+  }
+
+  async function fetchSession() {
+    const response = await fetch("/auth/session");
+    authState = await response.json();
+    updateTeacherControls();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +66,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +85,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${authState.authenticated ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">Unregister</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -86,29 +141,88 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Unable to log in.", "error");
+        return;
+      }
+
+      authState = {
+        authenticated: true,
+        username: result.username,
+      };
+      updateTeacherControls();
+      setAdminPanelOpen(false);
+      loginForm.reset();
+      await fetchActivities();
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", {
+        method: "POST",
+      });
+      const result = await response.json();
+
+      authState = {
+        authenticated: false,
+        username: null,
+      };
+      updateTeacherControls();
+      await fetchActivities();
+      showMessage(result.message || "Signed out", "success");
+    } catch (error) {
+      showMessage("Failed to log out. Please try again.", "error");
+      console.error("Error logging out:", error);
+    }
+  });
+
+  adminToggle.addEventListener("click", () => {
+    if (authState.authenticated) {
+      showMessage(`Signed in as ${authState.username}`, "success");
+      return;
+    }
+
+    setAdminPanelOpen(adminPanel.classList.contains("hidden"));
+  });
+
+  adminPanelClose.addEventListener("click", () => {
+    setAdminPanelOpen(false);
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -130,31 +244,20 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
-  fetchActivities();
+  fetchSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,41 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-bar">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="admin-controls">
+          <button id="admin-toggle" class="icon-button" type="button" aria-haspopup="dialog" aria-controls="admin-panel" aria-expanded="false">
+            <span class="icon-button__icon" aria-hidden="true">👤</span>
+            <span id="admin-toggle-label">Teacher Login</span>
+          </button>
+          <button id="logout-button" class="secondary-button hidden" type="button">Log Out</button>
+        </div>
+      </div>
     </header>
+
+    <div id="admin-panel" class="admin-panel hidden" role="dialog" aria-modal="true" aria-labelledby="admin-panel-title">
+      <div class="admin-panel__card">
+        <div class="admin-panel__header">
+          <h3 id="admin-panel-title">Teacher Login</h3>
+          <button id="admin-panel-close" class="icon-button icon-button--small" type="button" aria-label="Close login panel">✕</button>
+        </div>
+        <p class="admin-panel__copy">Only teachers can register or unregister students.</p>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Teacher Username:</label>
+            <input type="text" id="username" required placeholder="principal@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -22,7 +54,8 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Teacher Actions</h3>
+        <p id="teacher-status" class="info-banner">Log in as a teacher to manage student registrations.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -35,7 +68,7 @@
               <!-- Activity options will be loaded here -->
             </select>
           </div>
-          <button type="submit">Sign Up</button>
+          <button id="signup-button" type="submit">Register Student</button>
         </form>
         <div id="message" class="hidden"></div>
       </section>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,25 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 20px;
+}
+
+.admin-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 header h1 {
@@ -74,6 +87,62 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.admin-panel {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 10;
+}
+
+.admin-panel__card {
+  width: min(100%, 420px);
+  background-color: white;
+  border-radius: 10px;
+  padding: 24px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
+}
+
+.admin-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.admin-panel__copy {
+  margin-bottom: 18px;
+  color: #555;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon-button__icon {
+  font-size: 18px;
+}
+
+.icon-button--small {
+  padding: 8px 10px;
+  min-width: auto;
+}
+
+.secondary-button {
+  background-color: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+}
+
+.secondary-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
 /* New styles for participants section */
 .participants-container {
   margin-top: 15px;
@@ -111,18 +180,15 @@ section h3 {
 }
 
 .delete-btn {
-  background: none;
-  border: none;
-  color: #c62828;
-  cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
-  transition: all 0.2s;
-  border-radius: 3px;
+  background-color: #ffe8e8;
+  color: #a61b1b;
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 999px;
 }
 
 .delete-btn:hover {
-  background-color: #ffebee;
+  background-color: #ffd4d4;
 }
 
 .participants-section p {
@@ -164,6 +230,18 @@ button:hover {
   background-color: #3949ab;
 }
 
+.info-banner {
+  margin-bottom: 16px;
+  padding: 12px;
+  border-radius: 4px;
+  background-color: #e8eefc;
+  color: #17337d;
+}
+
+.disabled-form {
+  opacity: 0.6;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -190,6 +268,23 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+@media (max-width: 767px) {
+  body {
+    padding: 12px;
+  }
+
+  .header-bar {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .admin-controls {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "principal@mergington.edu": "mergington-admin",
+  "coach.taylor@mergington.edu": "falcons-rule"
+}


### PR DESCRIPTION
## Summary
Add teacher authentication so only logged-in staff can register or unregister students for activities.

## What Changed
- add JSON-backed teacher credentials and session-based login/logout endpoints
- require teacher authentication for signup and unregister actions
- add a teacher login/logout interface in the app header
- hide registration and unregister controls from non-teacher users
- document the new admin mode flow and sample teacher accounts

Fixes #5